### PR TITLE
Upgrade Python version to 3.11 and add Jinja2 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for intake web app
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 
@@ -31,7 +31,8 @@ RUN pip install --no-cache-dir \
     google-auth-httplib2==0.2.0 \
     google-api-python-client==2.116.0 \
     python-dotenv==1.0.1 \
-    loguru==0.7.2
+    loguru==0.7.2 \
+    jinja2==3.1.3
 
 # Copy application code
 COPY shared/ /app/shared/


### PR DESCRIPTION
## Summary
Updated the Docker base image to use Python 3.11 and added Jinja2 as a project dependency.

## Key Changes
- Upgraded base Docker image from `python:3.10-slim` to `python:3.11-slim`
- Added `jinja2==3.1.3` to the pip dependencies list

## Details
This change modernizes the Python runtime environment to version 3.11, which provides performance improvements and the latest language features. The addition of Jinja2 indicates new templating functionality is being introduced to the application.

https://claude.ai/code/session_01CSL6mbgGiEuWvQa4sUr1rQ