### PR TITLE
Add support for SERVICE_ACCOUNT_JSON env var for cloud deployments

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -18,7 +18,8 @@ class Settings(BaseSettings):
 
     # Google Drive
     drive_root_folder_id: str
-    service_account_json_path: str
+    # Path to service account JSON file (optional if SERVICE_ACCOUNT_JSON env var is set)
+    service_account_json_path: Optional[str] = None
 
     # Local Storage
     local_root: str = Field(default="F:\\FamilyArchive")


### PR DESCRIPTION
- DriveClient now checks SERVICE_ACCOUNT_JSON env var first (containing the full JSON content), then falls back to file path
- Made service_account_json_path optional in Settings when using env var
- This enables Railway/Heroku deployments without mounting files

https://claude.ai/code/session_01CSL6mbgGiEuWvQa4sUr1rQ